### PR TITLE
a few more things

### DIFF
--- a/spot/spot_manager.py
+++ b/spot/spot_manager.py
@@ -416,11 +416,13 @@ class SpotManager(object):
             Log.error("No network interface specifications found for {{availability_zone}}!", availability_zone=settings.availability_zone_group)
 
         settings.settings = None
-        settings.block_device_map = BlockDeviceMapping()
+        block_device_map = BlockDeviceMapping()
 
         # GENERIC BLOCK DEVICE MAPPING
         for dev, dev_settings in settings.block_device_map.items():
-            settings.block_device_map[dev] = BlockDeviceType(**unwrap(dev_settings))
+            block_device_map[dev] = BlockDeviceType(**unwrap(dev_settings))
+
+        settings.block_device_map = block_device_map
 
         # INCLUDE EPHEMERAL STORAGE IN BlockDeviceMapping
         num_ephemeral_volumes = ephemeral_storage[instance_type]["num"]

--- a/spot/spot_manager.py
+++ b/spot/spot_manager.py
@@ -206,6 +206,10 @@ class SpotManager(object):
                         cause=e
                     )
 
+                    if "Max spot instance count exceeded" in e.message:
+                        Log.note("No further spot requests will be attempted.")
+                        return net_new_utility, remaining_budget
+
         return net_new_utility, remaining_budget
 
     def remove_instances(self, net_new_utility):

--- a/spot/spot_manager.py
+++ b/spot/spot_manager.py
@@ -107,7 +107,10 @@ class SpotManager(object):
         if remaining_budget < 0:
             remaining_budget, net_new_utility = self.save_money(remaining_budget, net_new_utility)
 
-        if net_new_utility <= 0:
+        if net_new_utility < 0:
+            if self.settings.allowed_overage:
+                net_new_utility = Math.min(net_new_utility + self.settings.allowed_overage * utility_required, 0)
+
             net_new_utility = self.remove_instances(net_new_utility)
 
         if net_new_utility > 0:


### PR DESCRIPTION
These are some more things I added in the past week as I did the first pass through our workload.  Everything went swimmingly and the pass completed on time and within budget, consuming somewhere in the neighborhood of 50k instance-hours.  Yay!

In this PR:
- Somehow I screwed up or mismerged a fix I had for the BlockDeviceMapping stuff.  On the plus side, this saved us money as I really did not need the bigger volumes.
- I added detection of exceeding one's spot instance request limit.  There's nothing the script can do about this and without this code, it keeps trying various instance types at higher and higher cost-per-utility and eventually claims it can't find cheap enough utility, all the while spamming the console with errors.
- I added an `allowed_overage` parameter to settings.  This is a fraction of `required_utility` below which instances should not be killed to get down to `required_utility` even if we have more than `required_utility` running.  The reason I needed this was to combat a hysteresis effect where the script was adding and killing utility constantly, resulting in a really pretty sine-wave oscillation in my "Jobs Completed" graph (and wasted money).  Once I added this the graph stabilized to a very nice straight line.  Probably only an issue when one doesn't use the instance watcher to set up instances.
